### PR TITLE
Fixes crash that occurs when an AsynPing object is destroyed while timers are running

### DIFF
--- a/src/AsyncPing.cpp
+++ b/src/AsyncPing.cpp
@@ -19,6 +19,8 @@ AsyncPing::AsyncPing() {
 }
 
 AsyncPing::~AsyncPing() {
+  os_timer_disarm(&_timer);
+  os_timer_disarm(&_timer_recv);
   done();
 }
 

--- a/src/AsyncPing.cpp
+++ b/src/AsyncPing.cpp
@@ -16,6 +16,8 @@ AsyncPing::AsyncPing() {
   _on_recv = NULL;
   _on_sent = NULL;
   count_down = 0;
+  memset(&_timer, 0, sizeof(_timer));
+  memset(&_timer_recv, 0, sizeof(_timer_recv));
 }
 
 AsyncPing::~AsyncPing() {


### PR DESCRIPTION
If the object is destroyed, cancel() or the destructor does not disarm the timers (_timer in particular) leading to a crash in the framework, when accessing _timer during disarm.

Solution: disarm timers in the destructor



Exception Cause: 9  [LoadStoreAlignmentCause: Load or store to an unaligned address]

0x40105c05: ets_timer_disarm at ??:?
0x4026dba8: pp_disable_idle_timer at ??:?
0x4026ec4f: DefFreqCalTimerCB at ??:?
0x40253945: ethernet_input_LWIP2 at /home/gauchard/dev/esp8266/esp8266/tools/sdk/lwip2/builder/lwip2-src/src/netif/ethernet.c:188
0x4026e539: pp_tx_idle_timeout at ??:?
0x4026de8b: ppPeocessRxPktHdr at ??:?
0x4023a92b: loop_task(ETSEventTag*) at C:\Users\sascha\.platformio\packages\framework-arduinoespressif8266\cores\esp8266/core_esp8266_main.cpp:133
0x40000f49: ?? ??:0
0x40000f49: ?? ??:0
0x40000e19: ?? ??:0
0x40001878: ?? ??:0
0x40105474: call_user_start_local at ??:?
0x4010547a: call_user_start_local at ??:?
0x4010000d: call_user_start at ??:?
0x40250f7e: __ssputs_r at /home/earle/src/esp-quick-toolchain/repo/newlib/newlib/libc/stdio/nano-vfprintf.c:233
0x40250f7e: __ssputs_r at /home/earle/src/esp-quick-toolchain/repo/newlib/newlib/libc/stdio/nano-vfprintf.c:233
0x40250f7e: __ssputs_r at /home/earle/src/esp-quick-toolchain/repo/newlib/newlib/libc/stdio/nano-vfprintf.c:233
0x40250cce: __d2b at /home/earle/src/esp-quick-toolchain/repo/newlib/newlib/libc/stdlib/mprec.c:786
0x4024b76c: _printf_i at /home/earle/src/esp-quick-toolchain/repo/newlib/newlib/libc/stdio/nano-vfprintf_i.c:244
0x40250cce: __d2b at /home/earle/src/esp-quick-toolchain/repo/newlib/newlib/libc/stdlib/mprec.c:786
0x4024f70d: _dtoa_r at /home/earle/src/esp-quick-toolchain/repo/newlib/newlib/libc/stdlib/dtoa.c:858
0x40250cce: __d2b at /home/earle/src/esp-quick-toolchain/repo/newlib/newlib/libc/stdlib/mprec.c:786
0x4024f70d: _dtoa_r at /home/earle/src/esp-quick-toolchain/repo/newlib/newlib/libc/stdlib/dtoa.c:858
0x40250f7e: __ssputs_r at /home/earle/src/esp-quick-toolchain/repo/newlib/newlib/libc/stdio/nano-vfprintf.c:233
0x40250f7e: __ssputs_r at /home/earle/src/esp-quick-toolchain/repo/newlib/newlib/libc/stdio/nano-vfprintf.c:233
0x4024b664: _printf_i at /home/earle/src/esp-quick-toolchain/repo/newlib/newlib/libc/stdio/nano-vfprintf_i.c:194 (discriminator 1)
0x40250f7e: __ssputs_r at /home/earle/src/esp-quick-toolchain/repo/newlib/newlib/libc/stdio/nano-vfprintf.c:233
0x4026efe7: pp_attach at ??:?
0x4026f036: pp_attach at ??:?
0x4026f142: pp_attach at ??:?
0x4026e0f3: ppTxPkt at ??:?
0x402614c7: ieee80211_output_pbuf at ??:?
0x40250f7e: __ssputs_r at /home/earle/src/esp-quick-toolchain/repo/newlib/newlib/libc/stdio/nano-vfprintf.c:233
0x401059f3: wdt_feed at ??:?
0x40250f7e: __ssputs_r at /home/earle/src/esp-quick-toolchain/repo/newlib/newlib/libc/stdio/nano-vfprintf.c:233
0x40253359: glue2esp_linkoutput at /home/gauchard/dev/esp8266/esp8266/tools/sdk/lwip2/builder/glue-esp/lwip-esp.c:299
0x40250eb0: __ssputs_r at /home/earle/src/esp-quick-toolchain/repo/newlib/newlib/libc/stdio/nano-vfprintf.c:180
0x402535db: new_linkoutput at /home/gauchard/dev/esp8266/esp8266/tools/sdk/lwip2/builder/glue-lwip/lwip-git.c:235
0x402539cc: ethernet_output at /home/gauchard/dev/esp8266/esp8266/tools/sdk/lwip2/builder/lwip2-src/src/netif/ethernet.c:312
0x402878d2: sleep_reset_analog_rtcreg_8266 at ??:?
0x4025b5d4: etharp_output_to_arp_index at /home/gauchard/dev/esp8266/esp8266/tools/sdk/lwip2/builder/lwip2-src/src/core/ipv4/etharp.c:770
0x40251168: _svfprintf_r at /home/earle/src/esp-quick-toolchain/repo/newlib/newlib/libc/stdio/nano-vfprintf.c:531
0x4025b828: etharp_output_LWIP2 at /home/gauchard/dev/esp8266/esp8266/tools/sdk/lwip2/builder/lwip2-src/src/core/ipv4/etharp.c:885
0x4025ce20: mem_malloc at /home/gauchard/dev/esp8266/esp8266/tools/sdk/lwip2/builder/lwip2-src/src/core/mem.c:210
0x4023db8c: malloc at C:\Users\sascha\.platformio\packages\framework-arduinoespressif8266\cores\esp8266\umm_malloc/umm_malloc.cpp:1677
0x40101f6a: pp_post at ??:?
0x4010536b: lmacRxDone at ??:?
0x40101f6a: pp_post at ??:?
0x40102c81: trc_NeedRTS at ??:?
0x40101f6a: pp_post at ??:?
0x4010536b: lmacRxDone at ??:?
0x40102e5a: trc_NeedRTS at ??:?
0x40102c81: trc_NeedRTS at ??:?
0x4010329a: wDev_ProcessFiq at ??:?
0x40102e5a: trc_NeedRTS at ??:?
0x4010329a: wDev_ProcessFiq at ??:?
0x4010126e: uart_rx_fifo_available at C:\Users\sascha\.platformio\packages\framework-arduinoespressif8266\cores\esp8266/uart.cpp:118
0x4000050c: ?? ??:0
0x40103034: wDev_ProcessFiq at ??:?
0x4000dd29: ?? ??:0
0x4000066d: ?? ??:0
